### PR TITLE
Add structured strategy schema and validation

### DIFF
--- a/actions/strategy.py
+++ b/actions/strategy.py
@@ -1,7 +1,34 @@
 import random
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 import actions.utils
 import actions.tree
+
+
+@dataclass
+class StrategySchema:
+    """Structured representation of a strategy.
+
+    Attributes
+    ----------
+    out: List[Dict[str, Any]]
+        List of outbound :class:`actions.tree.TreeSchema` dictionaries.
+    in_: List[Dict[str, Any]]
+        List of inbound :class:`actions.tree.TreeSchema` dictionaries.  The
+        attribute is named ``in_`` to avoid clashing with the ``in`` keyword in
+        Python, but serialisation uses the ``"in"`` key.
+    """
+
+    out: List[Dict[str, Any]]
+    in_: List[Dict[str, Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"out": self.out, "in": self.in_}
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "StrategySchema":
+        return StrategySchema(out=data.get("out", []), in_=data.get("in", []))
 
 
 class Strategy(object):
@@ -15,6 +42,44 @@ class Strategy(object):
 
         self.environment_id = environment_id
         self.fitness = -1000
+
+    # ------------------------------------------------------------------
+    #  Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise this strategy to a dictionary."""
+        return {
+            "out": [tree.to_dict() for tree in self.out_actions],
+            "in": [tree.to_dict() for tree in self.in_actions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any], logger) -> "Strategy":
+        """Create a :class:`Strategy` from a dictionary."""
+        Strategy.validate_dict(data, logger)
+        out = [actions.tree.ActionTree.from_dict("out", t, logger) for t in data.get("out", [])]
+        inn = [actions.tree.ActionTree.from_dict("in", t, logger) for t in data.get("in", [])]
+        return cls(inn, out)
+
+    @staticmethod
+    def validate_dict(data: Dict[str, Any], logger) -> None:
+        """Validate a strategy dictionary.
+
+        Parameters
+        ----------
+        data: Dict[str, Any]
+            Dictionary describing the strategy.  The function raises
+            ``ValueError`` if the dictionary is malformed.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("Strategy must be a dictionary")
+        for direction in ("out", "in"):
+            trees = data.get(direction, [])
+            if not isinstance(trees, list):
+                raise ValueError(f"{direction} trees must be a list")
+            for tree in trees:
+                actions.tree.ActionTree.validate_dict(tree, direction, logger)
 
     def __str__(self):
         """

--- a/actions/tree.py
+++ b/actions/tree.py
@@ -1,15 +1,62 @@
-"""
-Defines an action tree. Action trees are comprised of a trigger and a tree of actions.
+"""Action tree utilities and dataclasses.
+
+This module previously relied purely on a string representation for action
+trees.  In order to support external tools and easier validation we now expose
+structured (JSON serialisable) schemas.  The schemas are simple dataclasses
+representing a trigger and a nested set of actions.  ``actions.utils.parse``
+and :pyclass:`actions.strategy.Strategy` make use of these helpers to parse and
+serialise strategies.
 """
 
 import random
 import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 import anytree
 from anytree.exporter import DotExporter
 
 import actions.utils
 import actions.trigger
+import actions.action
+
+
+@dataclass
+class ActionNodeSchema:
+    """Serialized representation of a single action node.
+
+    Attributes
+    ----------
+    action: str
+        String representation of the action.  This is the same format used in
+        the legacy string strategies, e.g. ``"drop"`` or
+        ``"tamper{TCP:flags:replace:R}"``.
+    left: Optional["ActionNodeSchema"]
+        Sub action executed on the left branch.
+    right: Optional["ActionNodeSchema"]
+        Sub action executed on the right branch.  Only branching actions may
+        specify a right node.
+    """
+
+    action: str
+    left: Optional["ActionNodeSchema"] = None
+    right: Optional["ActionNodeSchema"] = None
+
+
+@dataclass
+class TreeSchema:
+    """Serialized representation of an :class:`ActionTree`.
+
+    Parameters
+    ----------
+    trigger: str
+        String representation of the trigger (``protocol:field:value[:gas]``)
+    action: Optional[ActionNodeSchema]
+        Root action for the tree.  ``None`` denotes an empty tree.
+    """
+
+    trigger: str
+    action: Optional[ActionNodeSchema] = None
 
 
 class ActionTreeParseError(Exception):
@@ -36,6 +83,85 @@ class ActionTree():
         self.direction = direction
         self.environment_id = None
         self.ran = False
+
+    # ------------------------------------------------------------------
+    #  Serialization helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _node_to_dict(node):
+        """Serialise an action node into :class:`ActionNodeSchema` form."""
+        if not node:
+            return None
+        data = {"action": str(node)}
+        left = ActionTree._node_to_dict(getattr(node, "left", None))
+        right = ActionTree._node_to_dict(getattr(node, "right", None))
+        if left is not None:
+            data["left"] = left
+        if right is not None:
+            data["right"] = right
+        return data
+
+    @staticmethod
+    def _node_from_dict(direction, data, logger):
+        """Build an action node from a serialised representation."""
+        if not data:
+            return None
+        action_obj = actions.action.Action.parse_action(data["action"], direction, logger)
+        if not action_obj:
+            raise ValueError("Unknown action %s" % data["action"])
+        action_obj.left = ActionTree._node_from_dict(direction, data.get("left"), logger)
+        action_obj.right = ActionTree._node_from_dict(direction, data.get("right"), logger)
+        return action_obj
+
+    @staticmethod
+    def _validate_node_dict(direction, data, logger):
+        """Validate a serialised action node.
+
+        Ensures the action exists and that child placement obeys terminal and
+        branching constraints.
+        """
+        if not isinstance(data, dict) or "action" not in data:
+            raise ValueError("Action node must be a dict with an 'action' key")
+        action_obj = actions.action.Action.parse_action(data["action"], direction, logger)
+        if not action_obj:
+            raise ValueError("Unknown action %s" % data["action"])
+        if action_obj.terminal and (data.get("left") or data.get("right")):
+            raise ValueError("Terminal action %s cannot have children" % data["action"])
+        if not action_obj.branching and data.get("right"):
+            raise ValueError("Non-branching action %s cannot have right child" % data["action"])
+        if data.get("left"):
+            ActionTree._validate_node_dict(direction, data["left"], logger)
+        if data.get("right"):
+            ActionTree._validate_node_dict(direction, data["right"], logger)
+
+    def to_dict(self):
+        """Serialise this tree into :class:`TreeSchema` form."""
+        return {
+            "trigger": str(self.trigger) if self.trigger else "",
+            "action": ActionTree._node_to_dict(self.action_root),
+        }
+
+    @classmethod
+    def from_dict(cls, direction, data, logger):
+        """Create an :class:`ActionTree` from a :class:`TreeSchema` dict."""
+        cls.validate_dict(data, direction, logger)
+        tree = cls(direction)
+        tree.trigger = actions.trigger.Trigger.parse(data["trigger"])
+        tree.action_root = ActionTree._node_from_dict(direction, data.get("action"), logger)
+        return tree
+
+    @staticmethod
+    def validate_dict(data, direction, logger):
+        """Validate a :class:`TreeSchema` dictionary."""
+        if not isinstance(data, dict):
+            raise ValueError("Tree must be a dictionary")
+        if "trigger" not in data:
+            raise ValueError("Tree missing trigger")
+        if actions.trigger.Trigger.parse(data["trigger"]) is None:
+            raise ValueError("Invalid trigger %s" % data["trigger"])
+        if "action" in data and data["action"] is not None:
+            ActionTree._validate_node_dict(direction, data["action"], logger)
 
     def initialize(self, num_actions, environment_id, allow_terminal=True, disabled=None):
         """

--- a/actions/utils.py
+++ b/actions/utils.py
@@ -50,9 +50,30 @@ class SkipStrategyException(Exception):
 
 
 def parse(requested_trees, logger):
+    """Parse a strategy description into a :class:`actions.strategy.Strategy`.
+
+    ``requested_trees`` may be supplied either as the historical string
+    representation or as a structured dictionary/JSON object.  When a dictionary
+    (or JSON string) is provided, it is validated and converted using the new
+    schema defined in :mod:`actions.tree` and :mod:`actions.strategy`.
     """
-    Parses a string representation of a solution into its object form.
-    """
+
+    # If a dictionary was provided, assume it already represents the schema
+    if isinstance(requested_trees, dict):
+        return actions.strategy.Strategy.from_dict(requested_trees, logger)
+
+    # If this looks like a JSON object, attempt to parse it as such
+    if isinstance(requested_trees, str) and requested_trees.strip().startswith("{"):
+        try:
+            data = json.loads(requested_trees)
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            return actions.strategy.Strategy.from_dict(data, logger)
+
+    if not isinstance(requested_trees, str):
+        raise ValueError("Strategy description must be string or dict")
+
     # First, strip off any hanging quotes at beginning/end of the strategy
     if requested_trees.startswith("\""):
         requested_trees = requested_trees[1:]

--- a/tests/test_strategy_schema.py
+++ b/tests/test_strategy_schema.py
@@ -1,0 +1,42 @@
+import pytest
+import actions.utils
+import actions.strategy
+
+
+def test_valid_strategy_dict(logger):
+    data = {
+        "out": [
+            {"trigger": "TCP:flags:S", "action": {"action": "drop"}}
+        ],
+        "in": []
+    }
+    strat = actions.utils.parse(data, logger)
+    assert isinstance(strat, actions.strategy.Strategy)
+    assert str(strat).strip() == "[TCP:flags:S]-drop-| \\/"
+    assert strat.to_dict() == data
+
+
+def test_invalid_strategy_missing_trigger(logger):
+    bad = {"out": [{"action": {"action": "drop"}}], "in": []}
+    with pytest.raises(ValueError):
+        actions.utils.parse(bad, logger)
+
+
+def test_invalid_strategy_unknown_action(logger):
+    bad = {"out": [{"trigger": "TCP:flags:S", "action": {"action": "nope"}}], "in": []}
+    with pytest.raises(ValueError):
+        actions.utils.parse(bad, logger)
+
+
+def test_invalid_strategy_bad_children(logger):
+    bad = {
+        "out": [
+            {
+                "trigger": "TCP:flags:S",
+                "action": {"action": "drop", "left": {"action": "drop"}}
+            }
+        ],
+        "in": []
+    }
+    with pytest.raises(ValueError):
+        actions.utils.parse(bad, logger)


### PR DESCRIPTION
## Summary
- introduce dataclass/JSON schemas for action trees and strategies
- add serialization and validation utilities and update parsing to use them
- cover new schema with unit tests for valid and invalid strategy definitions

## Testing
- `PYTHONPATH=. pytest tests/test_strategy_schema.py -q`
- `PYTHONPATH=. pytest tests/test_parse.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68be04fe8a408331b2f85de459e08211